### PR TITLE
Import updates to fix tool loading

### DIFF
--- a/arcpro_npg/npg/npg/npg_bool_hlp.py
+++ b/arcpro_npg/npg/npg/npg_bool_hlp.py
@@ -598,6 +598,8 @@ def add_intersections(
         p_w = _w_(z, p1_, False)  # use _w_ from _wn_clip_
         p_i = np.nonzero(p_w)[0]
         p_o = np.nonzero(p_w + 1)[0]
+        p_in = p_neq[p_i]   # in ids
+        p_out = p_neq[p_o]  # out ids
         p_ioo = np.zeros(p0_.shape, dtype='int')  # create the output indices
         p_ioo[:, 0] = p_ids  # p0 ids (i)n (o)ut (o)n -> ``ioo``
         p_ioo[p_in, 1] = 1

--- a/arcpro_npg/npg/npg/npg_bool_hlp.py
+++ b/arcpro_npg/npg/npg/npg_bool_hlp.py
@@ -34,10 +34,9 @@ Functions for boolean operations on polygons:
 import sys
 import numpy as np
 from numpy.lib.stride_tricks import sliding_window_view as swv
-import npg
-from npg.npGeo import roll_arrays
-from npg_geom_hlp import sort_segment_pairs
-from npg.npg_plots import plot_polygons, plot_2d  # noqa
+from .npGeo import roll_arrays
+from .npg_geom_hlp import sort_segment_pairs
+from .npg_plots import plot_polygons, plot_2d  # noqa
 
 ft = {"bool": lambda x: repr(x.astype(np.int32)),
       "float_kind": '{: 6.2f}'.format}
@@ -599,8 +598,6 @@ def add_intersections(
         p_w = _w_(z, p1_, False)  # use _w_ from _wn_clip_
         p_i = np.nonzero(p_w)[0]
         p_o = np.nonzero(p_w + 1)[0]
-        p_in = p_neq[p_i]   # in ids
-        p_out = p_neq[p_o]  # out ids
         p_ioo = np.zeros(p0_.shape, dtype='int')  # create the output indices
         p_ioo[:, 0] = p_ids  # p0 ids (i)n (o)ut (o)n -> ``ioo``
         p_ioo[p_in, 1] = 1

--- a/arcpro_npg/npg/tbx_tools.py
+++ b/arcpro_npg/npg/tbx_tools.py
@@ -891,7 +891,7 @@ def pick_tool(tool, in_fc, out_fc, gdb, name):
         shifter(in_fc, gdb, name, dX=dX, dY=dY)
     elif tool == 'Dissolve Boundaries':
         dissolve_boundaries(in_fc, gdb, name)
-
+    #
     # ---- Triangulation
     elif tool == 'Delaunay':                     # ---- (1) Delaunay
         out_kind = sys.argv[4].upper()

--- a/arcpro_npg/npg/tbx_tools.py
+++ b/arcpro_npg/npg/tbx_tools.py
@@ -889,9 +889,9 @@ def pick_tool(tool, in_fc, out_fc, gdb, name):
         dX = float(sys.argv[4])
         dY = float(sys.argv[5])
         shifter(in_fc, gdb, name, dX=dX, dY=dY)
-    # elif tool == 'Dissolve Boundaries':
-    #     dissolve_boundaries(in_fc, gdb, name)
-    #
+    elif tool == 'Dissolve Boundaries':
+        dissolve_boundaries(in_fc, gdb, name)
+
     # ---- Triangulation
     elif tool == 'Delaunay':                     # ---- (1) Delaunay
         out_kind = sys.argv[4].upper()

--- a/arcpro_npg/npg/tbx_tools.py
+++ b/arcpro_npg/npg/tbx_tools.py
@@ -181,7 +181,7 @@ tool_list = [
     'Extent Sort', 'Geometry Sort',
     'Area Sort', 'Length Sort',
     'Fill Holes', 'Keep Holes',
-    'Rotate Features', 'Shift Features',
+    'Rotate Features', 'Shift Features', 'Dissolve Boundaries',
     'Delaunay', 'Voronoi']
 cont_list = ['Bounding Circles', 'Convex Hulls', 'Extent Polys',
              'Minimum area bounding rectangle']

--- a/arcpro_npg/npg/tbx_tools.py
+++ b/arcpro_npg/npg/tbx_tools.py
@@ -145,7 +145,7 @@ from npg.npGeo import arrays_to_Geo  # Geo
 from npg.npg_arc_npg import (get_SR, get_shape_K, fc_to_Geo, Geo_to_fc,
                              Geo_to_arc_shapes, fc_data)
 from npg.npg_create import circle, hex_flat, hex_pointy, rectangle, triangle
-from npg.npg_bool_ops import merge_  # Changed from npg_overlay
+from npg.npg_bool_ops import merge_, union_adj  # Changed from npg_overlay
 
 from scipy.spatial import Voronoi  # Delaunay
 
@@ -181,7 +181,7 @@ tool_list = [
     'Extent Sort', 'Geometry Sort',
     'Area Sort', 'Length Sort',
     'Fill Holes', 'Keep Holes',
-    'Rotate Features', 'Shift Features', 'Dissolve Boundaries',
+    'Rotate Features', 'Shift Features',
     'Delaunay', 'Voronoi']
 cont_list = ['Bounding Circles', 'Convex Hulls', 'Extent Polys',
              'Minimum area bounding rectangle']
@@ -697,7 +697,7 @@ def dissolve_boundaries(in_fc, gdb, name):
     g, oids, shp_kind, k, m, SR = _in_(in_fc, info)
     out_kind = shp_kind
     x, y = g.LL
-    g0 = dissolve(g, asGeo=True)
+    g0 = union_adj(g, asGeo=True)
     tweet("g0")
     # g0 = arrays_to_Geo(g0, kind=2, info="extent")
     g0 = g0.translate(dx=x, dy=y)
@@ -889,8 +889,8 @@ def pick_tool(tool, in_fc, out_fc, gdb, name):
         dX = float(sys.argv[4])
         dY = float(sys.argv[5])
         shifter(in_fc, gdb, name, dX=dX, dY=dY)
-    elif tool == 'Dissolve Boundaries':
-        dissolve_boundaries(in_fc, gdb, name)
+    # elif tool == 'Dissolve Boundaries':
+    #     dissolve_boundaries(in_fc, gdb, name)
     #
     # ---- Triangulation
     elif tool == 'Delaunay':                     # ---- (1) Delaunay

--- a/arcpro_npg/npg/tbx_tools.py
+++ b/arcpro_npg/npg/tbx_tools.py
@@ -145,7 +145,7 @@ from npg.npGeo import arrays_to_Geo  # Geo
 from npg.npg_arc_npg import (get_SR, get_shape_K, fc_to_Geo, Geo_to_fc,
                              Geo_to_arc_shapes, fc_data)
 from npg.npg_create import circle, hex_flat, hex_pointy, rectangle, triangle
-from npg.npg_overlay import dissolve, merge_
+from npg.npg_bool_ops import merge_  # Changed from npg_overlay
 
 from scipy.spatial import Voronoi  # Delaunay
 


### PR DESCRIPTION
Fixes https://github.com/Dan-Patterson/numpy_geometry/issues/5

1. The absolute imports in `npg_bool_hlp.py` don't resolve correctly, so I moved them to be relative imports.
2. In `tbx_tools.py`, the line `from npg.npg_overlay import dissolve, merge_` has two issues:
  a. There is no function in the repo called `dissolve`, causing an import error. A quick read suggests this might be `union_adj` inside `npg_bool_ops`, so I've updated accordingly.
  b. The function `merge_` exists in `npg_bool_ops`, not `npg_overlay`, so I've updated accordingly.

I've only tested this with a couple of tools, but it seems to run fine.